### PR TITLE
refactor: use class instead of className

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Game state can be observed by binding to props.
 | `history`   |           ✓           |          | Array of all moves as SAN strings, e.g. `['d4','Nf6']`                               |
 | `isGameOver`|           ✓           |          | True if the game is over. Listen for the [gameOver event](#events) for more details. |
 | `fen`       |           ✓           |    ✓     | Current position in [FEN](https://www.chessprogramming.org/Forsyth-Edwards_Notation) |
-| `className` |                       |    ✓     | CSS class applied to children instead of default (see [Styling](#styling)).          |
+| `class` |                       |    ✓     | CSS class applied to children instead of default (see [Styling](#styling)).          |
 
 All readable props are bindable and updated whenever the game state changes.
 Writable props are only used when the component is created.
@@ -116,7 +116,7 @@ Svelte-chess exports the MoveEvent and GameOverEvent types.
 ## Styling
 
 The stylesheet shipped with Chessground is used by default. To restyle the 
-board, pass the `className` prop and import a stylesheet.
+board, pass the `class` prop and import a stylesheet.
 
 Example with custom stylesheet:
 
@@ -124,7 +124,7 @@ Example with custom stylesheet:
         import { Chess } from 'svelte-chess';
     </script>
     <link rel="stylesheet" href="/my-style.css" />
-    <Chess className="my-class" />
+    <Chess class="my-class" />
 
 A sample stylesheet can be found in [/static/style-paper.css](https://github.com/gtim/svelte-chess/blob/main/static/style-paper.css).
 

--- a/src/lib/Chess.svelte
+++ b/src/lib/Chess.svelte
@@ -29,7 +29,8 @@
 	export let fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 
 	// non-bindable
-	export let className: string | undefined = undefined;
+	let className: string | undefined = undefined;
+	export { className as class };
 
 	// API: only accessible through props and methods
 	let api: Api | undefined = undefined;

--- a/src/lib/PromotionDialog.svelte
+++ b/src/lib/PromotionDialog.svelte
@@ -3,7 +3,8 @@
 
 	export let square: Square;
 	export let callback: (promotion: PieceSymbol) => void;
-	export let className: string | undefined = undefined;
+	let className: string | undefined = undefined;
+	export { className as class };
 
 	const left = 100 * squareToFileNumber(square) / 8;
 	const white = square.charAt(1) === '8';

--- a/src/routes/css/+page.svelte
+++ b/src/routes/css/+page.svelte
@@ -5,5 +5,5 @@
 <link rel="stylesheet" href="./style-paper.css" />
 
 <div style="max-width:512px;margin:0 auto;">
-	<Chess className="cg-paper" />
+	<Chess class="cg-paper" />
 </div>


### PR DESCRIPTION
Use the Svelte™ pattern to export the `class` attribute from components. Also, changed all ocurrences of `className` in the docs.